### PR TITLE
Add Air setup and improve Makefile for development workflow

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,13 @@
+# Where Air should run your app
+root = "."
+tmp_dir = "tmp"
+
+[build]
+cmd = "go build -o ./tmp/app ./cmd/camp"
+bin = "./tmp/app"
+include_ext = ["go"]
+exclude_dir = ["bin", "tmp", "vendor"]
+delay = 200
+
+[log]
+time = true

--- a/README.md
+++ b/README.md
@@ -47,9 +47,16 @@ cp .env.example .env
 # Edit .env with your settings
 ```
 
-4. Run the application:
+4. Install Air (optional): [documentation](https://github.com/air-verse/air)
+
+5. Run the application (development mode):
 ```bash
 // make sure to install `make` before this.
+make dev
+```
+
+6. Run the application (production mode):
+```bash
 make run
 ```
 

--- a/makefile
+++ b/makefile
@@ -1,6 +1,22 @@
-run: build
-	@./bin/camp
+APP=camp
+BIN=./bin/$(APP)
+MAIN=cmd/camp/main.go
 
+run: build
+	@$(BIN)
 
 build:
-	@go build -o ./bin/camp cmd/camp/main.go
+	@go build -o $(BIN) $(MAIN)
+
+dev:
+	@air
+
+tidy:
+	@go mod tidy
+
+fmt:
+	@go fmt ./...
+
+clean:
+	@rm -rf bin/* tmp/*
+


### PR DESCRIPTION
This update adds support for running the project with Air during development.
The repository now includes an `.air.toml` configuration file and an updated
Makefile with a `dev` command to start the auto-reload server.

Changes included:
- Added `.air.toml` for local development
- Added `dev` and other necessary commands to the Makefile
- Made development setup easier for contributors
- updated README  with Air setup

This prepares the project for a smoother development process and makes local
changes easier to test without manual rebuilds.
