### PR TITLE
perf: add bulk insert support for tags

### DIFF
--- a/internal/contact/repository.go
+++ b/internal/contact/repository.go
@@ -141,7 +141,7 @@ func insertTagIfNotExist(txn *sql.Tx, tags []Tag) error {
 	args := make([]interface{}, len(tags))
 
 	for i, tag := range tags {
-		placeholders[i] = "?"
+		placeholders[i] = "(?)"
 		args[i] = tag.Text
 	}
 


### PR DESCRIPTION
This PR replaces the previous per-tag INSERT logic with a single bulk INSERT statement using `INSERT OR IGNORE`. This reduces the number of database round trips and improves performance when inserting many tags.
