### PR TITLE
feat: Add input validation to contact creation endpoint

### DIFF
--- a/internal/contact/handler.go
+++ b/internal/contact/handler.go
@@ -15,13 +15,17 @@ func NewHandler(repo *Repository) *Handler {
 }
 
 func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
-
-	// todo: request validation
 	var contactBody Contact
 
 	if err := json.NewDecoder(r.Body).Decode(&contactBody); err != nil {
 		fmt.Println(err)
 		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	// Validate request
+	if errs := ValidateCreateContactRequest(&contactBody); len(errs) > 0 {
+		respondValidationError(w, errs)
 		return
 	}
 
@@ -42,4 +46,17 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 		"id": createdId,
 	}
 	json.NewEncoder(w).Encode(resp)
+}
+
+// respondValidationError sends a 400 Bad Request response with validation error details
+func respondValidationError(w http.ResponseWriter, errors []ContactValidationError) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+
+	response := ValidationErrorResponse{
+		Error:   "validation failed",
+		Details: errors,
+	}
+
+	json.NewEncoder(w).Encode(response)
 }

--- a/internal/contact/handler_test.go
+++ b/internal/contact/handler_test.go
@@ -1,0 +1,262 @@
+package contact
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandler_Create(t *testing.T) {
+	db := setupDB(t)
+	repo := NewRepository(db)
+	handler := NewHandler(repo)
+
+	tests := []struct {
+		name             string
+		body             interface{}
+		expectedStatus   int
+		validateResponse func(t *testing.T, resp *httptest.ResponseRecorder)
+	}{
+		{
+			name: "valid contact creation",
+			body: map[string]interface{}{
+				"email":      "test@example.com",
+				"first_name": "John",
+				"last_name":  "Doe",
+			},
+			expectedStatus: http.StatusCreated,
+			validateResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				if resp.Code != http.StatusCreated {
+					t.Errorf("Expected status %d, got %d", http.StatusCreated, resp.Code)
+				}
+				var result map[string]interface{}
+				if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+					t.Fatalf("Failed to parse response: %v", err)
+				}
+				if _, ok := result["id"]; !ok {
+					t.Error("Response should contain 'id' field")
+				}
+			},
+		},
+		{
+			name: "empty email - should fail",
+			body: map[string]interface{}{
+				"email":      "",
+				"first_name": "John",
+			},
+			expectedStatus: http.StatusBadRequest,
+			validateResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				var result ValidationErrorResponse
+				if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+					t.Fatalf("Failed to parse response: %v", err)
+				}
+				if result.Error != "validation failed" {
+					t.Errorf("Expected error 'validation failed', got '%s'", result.Error)
+				}
+				if len(result.Details) == 0 {
+					t.Error("Expected validation error details")
+				}
+				foundEmailError := false
+				for _, detail := range result.Details {
+					if detail.Field == "email" && detail.Message == "email is required" {
+						foundEmailError = true
+						break
+					}
+				}
+				if !foundEmailError {
+					t.Error("Expected email validation error")
+				}
+			},
+		},
+		{
+			name: "invalid email format - should fail",
+			body: map[string]interface{}{
+				"email":      "not-an-email",
+				"first_name": "John",
+			},
+			expectedStatus: http.StatusBadRequest,
+			validateResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				var result ValidationErrorResponse
+				if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+					t.Fatalf("Failed to parse response: %v", err)
+				}
+				foundEmailError := false
+				for _, detail := range result.Details {
+					if detail.Field == "email" && detail.Message == "email must be valid format" {
+						foundEmailError = true
+						break
+					}
+				}
+				if !foundEmailError {
+					t.Error("Expected email format validation error")
+				}
+			},
+		},
+		{
+			name: "no name fields - should fail",
+			body: map[string]interface{}{
+				"email": "test@example.com",
+			},
+			expectedStatus: http.StatusBadRequest,
+			validateResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				var result ValidationErrorResponse
+				if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+					t.Fatalf("Failed to parse response: %v", err)
+				}
+				foundNameError := false
+				for _, detail := range result.Details {
+					if detail.Field == "name" {
+						foundNameError = true
+						break
+					}
+				}
+				if !foundNameError {
+					t.Error("Expected name validation error")
+				}
+			},
+		},
+		{
+			name: "empty first_name and last_name - should fail",
+			body: map[string]interface{}{
+				"email":      "test@example.com",
+				"first_name": "",
+				"last_name":  "",
+			},
+			expectedStatus: http.StatusBadRequest,
+			validateResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				var result ValidationErrorResponse
+				if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+					t.Fatalf("Failed to parse response: %v", err)
+				}
+				foundNameError := false
+				for _, detail := range result.Details {
+					if detail.Field == "name" {
+						foundNameError = true
+						break
+					}
+				}
+				if !foundNameError {
+					t.Error("Expected name validation error")
+				}
+			},
+		},
+		{
+			name: "valid contact with only first_name",
+			body: map[string]interface{}{
+				"email":      "test2@example.com",
+				"first_name": "Jane",
+			},
+			expectedStatus: http.StatusCreated,
+			validateResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				if resp.Code != http.StatusCreated {
+					t.Errorf("Expected status %d, got %d", http.StatusCreated, resp.Code)
+				}
+			},
+		},
+		{
+			name: "valid contact with only last_name",
+			body: map[string]interface{}{
+				"email":     "test3@example.com",
+				"last_name": "Smith",
+			},
+			expectedStatus: http.StatusCreated,
+			validateResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				if resp.Code != http.StatusCreated {
+					t.Errorf("Expected status %d, got %d", http.StatusCreated, resp.Code)
+				}
+			},
+		},
+		{
+			name: "email too long - should fail",
+			body: map[string]interface{}{
+				"email":      "a" + string(bytes.Repeat([]byte("x"), 250)) + "@example.com",
+				"first_name": "John",
+			},
+			expectedStatus: http.StatusBadRequest,
+			validateResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				var result ValidationErrorResponse
+				if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+					t.Fatalf("Failed to parse response: %v", err)
+				}
+				foundEmailError := false
+				for _, detail := range result.Details {
+					if detail.Field == "email" && detail.Message == "email must not exceed 255 characters" {
+						foundEmailError = true
+						break
+					}
+				}
+				if !foundEmailError {
+					t.Errorf("Expected email length validation error, got: %v", result.Details)
+				}
+			},
+		},
+		{
+			name: "invalid phone format - should fail",
+			body: map[string]interface{}{
+				"email":      "test@example.com",
+				"first_name": "John",
+				"phone":      "123",
+			},
+			expectedStatus: http.StatusBadRequest,
+			validateResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				var result ValidationErrorResponse
+				if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+					t.Fatalf("Failed to parse response: %v", err)
+				}
+				foundPhoneError := false
+				for _, detail := range result.Details {
+					if detail.Field == "phone" {
+						foundPhoneError = true
+						break
+					}
+				}
+				if !foundPhoneError {
+					t.Error("Expected phone validation error")
+				}
+			},
+		},
+		{
+			name:           "invalid JSON - should fail",
+			body:           "invalid json string",
+			expectedStatus: http.StatusBadRequest,
+			validateResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				// Should return "invalid json" error
+				if resp.Body.String() != "invalid json\n" {
+					t.Errorf("Expected 'invalid json' error, got: %s", resp.Body.String())
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var bodyBytes []byte
+			var err error
+
+			if str, ok := tt.body.(string); ok {
+				bodyBytes = []byte(str)
+			} else {
+				bodyBytes, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("Failed to marshal request body: %v", err)
+				}
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/api/contacts", bytes.NewBuffer(bodyBytes))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+
+			handler.Create(rr, req)
+
+			if rr.Code != tt.expectedStatus {
+				t.Errorf("Expected status %d, got %d. Body: %s", tt.expectedStatus, rr.Code, rr.Body.String())
+			}
+
+			if tt.validateResponse != nil {
+				tt.validateResponse(t, rr)
+			}
+		})
+	}
+}

--- a/internal/contact/validator.go
+++ b/internal/contact/validator.go
@@ -1,0 +1,131 @@
+package contact
+
+import (
+	"regexp"
+	"strings"
+)
+
+const (
+	maxEmailLength = 255
+	maxNameLength  = 100
+)
+
+// ContactValidationError represents a validation error for a specific field
+type ContactValidationError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+// ValidationErrorResponse represents the error response structure
+type ValidationErrorResponse struct {
+	Error   string                   `json:"error"`
+	Details []ContactValidationError `json:"details"`
+}
+
+var (
+	// emailRegex is a simple regex for email validation
+	// This matches most common email formats but is not fully RFC 5322 compliant
+	// For production, consider using a more robust library
+	emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`)
+
+	// phoneRegex matches common phone number formats
+	// Supports: +1234567890, (123) 456-7890, 123-456-7890, 1234567890
+	phoneRegex = regexp.MustCompile(`^[\+]?[(]?[0-9]{1,4}[)]?[-\s\.]?[(]?[0-9]{1,4}[)]?[-\s\.]?[0-9]{1,9}$`)
+)
+
+// isValidEmail checks if the email format is valid
+func isValidEmail(email string) bool {
+	if len(email) == 0 {
+		return false
+	}
+	return emailRegex.MatchString(email)
+}
+
+// isValidPhone checks if the phone number format is valid (optional field)
+func isValidPhone(phone string) bool {
+	if len(phone) == 0 {
+		return true // Phone is optional
+	}
+	// Remove common separators for validation
+	cleaned := strings.ReplaceAll(phone, " ", "")
+	cleaned = strings.ReplaceAll(cleaned, "-", "")
+	cleaned = strings.ReplaceAll(cleaned, "(", "")
+	cleaned = strings.ReplaceAll(cleaned, ")", "")
+	cleaned = strings.ReplaceAll(cleaned, ".", "")
+
+	// Check if it's a reasonable length (at least 7 digits, max 15)
+	if len(cleaned) < 7 || len(cleaned) > 15 {
+		return false
+	}
+
+	// Check if remaining characters are digits or +
+	hasDigit := false
+	for _, char := range cleaned {
+		if char >= '0' && char <= '9' {
+			hasDigit = true
+		} else if char != '+' {
+			return false
+		}
+	}
+	return hasDigit
+}
+
+// ValidateCreateContactRequest validates a contact creation request
+func ValidateCreateContactRequest(req *Contact) []ContactValidationError {
+	var errors []ContactValidationError
+
+	// Email validation - required
+	if req.Email == "" {
+		errors = append(errors, ContactValidationError{
+			Field:   "email",
+			Message: "email is required",
+		})
+	} else if !isValidEmail(req.Email) {
+		errors = append(errors, ContactValidationError{
+			Field:   "email",
+			Message: "email must be valid format",
+		})
+	} else if len(req.Email) > maxEmailLength {
+		errors = append(errors, ContactValidationError{
+			Field:   "email",
+			Message: "email must not exceed 255 characters",
+		})
+	}
+
+	// Name validation - at least one of first_name or last_name is required
+	firstNameTrimmed := strings.TrimSpace(req.FirstName)
+	lastNameTrimmed := strings.TrimSpace(req.LastName)
+
+	if firstNameTrimmed == "" && lastNameTrimmed == "" {
+		errors = append(errors, ContactValidationError{
+			Field:   "name",
+			Message: "at least one of first_name or last_name is required",
+		})
+	} else {
+		// Validate first_name length if provided
+		if firstNameTrimmed != "" && len(req.FirstName) > maxNameLength {
+			errors = append(errors, ContactValidationError{
+				Field:   "first_name",
+				Message: "first_name must not exceed 100 characters",
+			})
+		}
+
+		// Validate last_name length if provided
+		if lastNameTrimmed != "" && len(req.LastName) > maxNameLength {
+			errors = append(errors, ContactValidationError{
+				Field:   "last_name",
+				Message: "last_name must not exceed 100 characters",
+			})
+		}
+	}
+
+	// Phone validation - optional but must be valid if provided
+	if req.Phone != "" && !isValidPhone(req.Phone) {
+		errors = append(errors, ContactValidationError{
+			Field:   "phone",
+			Message: "phone must be valid format",
+		})
+	}
+
+	return errors
+}

--- a/internal/contact/validator_test.go
+++ b/internal/contact/validator_test.go
@@ -1,0 +1,279 @@
+package contact
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestValidateCreateContactRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     Contact
+		wantErr bool
+		errMsgs []string
+	}{
+		{
+			name: "valid contact with all fields",
+			req: Contact{
+				Email:     "test@example.com",
+				FirstName: "John",
+				LastName:  "Doe",
+				Phone:     "+1234567890",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid contact with only first_name",
+			req: Contact{
+				Email:     "test@example.com",
+				FirstName: "John",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid contact with only last_name",
+			req: Contact{
+				Email:    "test@example.com",
+				LastName: "Doe",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid contact without phone",
+			req: Contact{
+				Email:     "test@example.com",
+				FirstName: "John",
+				LastName:  "Doe",
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty email",
+			req: Contact{
+				FirstName: "John",
+				LastName:  "Doe",
+			},
+			wantErr: true,
+			errMsgs: []string{"email is required"},
+		},
+		{
+			name: "invalid email format - no @",
+			req: Contact{
+				Email:     "not-an-email",
+				FirstName: "John",
+			},
+			wantErr: true,
+			errMsgs: []string{"email must be valid format"},
+		},
+		{
+			name: "invalid email format - no domain",
+			req: Contact{
+				Email:     "test@",
+				FirstName: "John",
+			},
+			wantErr: true,
+			errMsgs: []string{"email must be valid format"},
+		},
+		{
+			name: "invalid email format - no TLD",
+			req: Contact{
+				Email:     "test@example",
+				FirstName: "John",
+			},
+			wantErr: true,
+			errMsgs: []string{"email must be valid format"},
+		},
+		{
+			name: "email too long",
+			req: Contact{
+				Email:     "a" + string(bytes.Repeat([]byte("x"), 250)) + "@example.com",
+				FirstName: "John",
+			},
+			wantErr: true,
+			errMsgs: []string{"email must not exceed 255 characters"},
+		},
+		{
+			name: "no name fields",
+			req: Contact{
+				Email: "test@example.com",
+			},
+			wantErr: true,
+			errMsgs: []string{"at least one of first_name or last_name is required"},
+		},
+		{
+			name: "empty first_name and last_name",
+			req: Contact{
+				Email:     "test@example.com",
+				FirstName: "",
+				LastName:  "",
+			},
+			wantErr: true,
+			errMsgs: []string{"at least one of first_name or last_name is required"},
+		},
+		{
+			name: "whitespace only first_name and last_name",
+			req: Contact{
+				Email:     "test@example.com",
+				FirstName: "   ",
+				LastName:  "   ",
+			},
+			wantErr: true,
+			errMsgs: []string{"at least one of first_name or last_name is required"},
+		},
+		{
+			name: "first_name too long",
+			req: Contact{
+				Email:     "test@example.com",
+				FirstName: string(make([]byte, 101)),
+				LastName:  "Doe",
+			},
+			wantErr: true,
+			errMsgs: []string{"first_name must not exceed 100 characters"},
+		},
+		{
+			name: "last_name too long",
+			req: Contact{
+				Email:     "test@example.com",
+				FirstName: "John",
+				LastName:  string(make([]byte, 101)),
+			},
+			wantErr: true,
+			errMsgs: []string{"last_name must not exceed 100 characters"},
+		},
+		{
+			name: "invalid phone format - too short",
+			req: Contact{
+				Email:     "test@example.com",
+				FirstName: "John",
+				Phone:     "123",
+			},
+			wantErr: true,
+			errMsgs: []string{"phone must be valid format"},
+		},
+		{
+			name: "invalid phone format - too long",
+			req: Contact{
+				Email:     "test@example.com",
+				FirstName: "John",
+				Phone:     string(make([]byte, 20)),
+			},
+			wantErr: true,
+			errMsgs: []string{"phone must be valid format"},
+		},
+		{
+			name: "valid phone formats",
+			req: Contact{
+				Email:     "test@example.com",
+				FirstName: "John",
+				Phone:     "+1234567890",
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple validation errors",
+			req: Contact{
+				Email: "",
+			},
+			wantErr: true,
+			errMsgs: []string{"email is required", "at least one of first_name or last_name is required"},
+		},
+		{
+			name: "valid email with subdomain",
+			req: Contact{
+				Email:     "test@mail.example.com",
+				FirstName: "John",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid email with special characters",
+			req: Contact{
+				Email:     "test.user+tag@example.co.uk",
+				FirstName: "John",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errors := ValidateCreateContactRequest(&tt.req)
+
+			if tt.wantErr {
+				if len(errors) == 0 {
+					t.Errorf("ValidateCreateContactRequest() expected errors but got none")
+					return
+				}
+
+				// Check if expected error messages are present
+				errorMessages := make(map[string]bool)
+				for _, err := range errors {
+					errorMessages[err.Message] = true
+				}
+
+				for _, expectedMsg := range tt.errMsgs {
+					if !errorMessages[expectedMsg] {
+						t.Errorf("ValidateCreateContactRequest() expected error message '%s' but didn't find it. Got errors: %v", expectedMsg, errors)
+					}
+				}
+			} else {
+				if len(errors) > 0 {
+					t.Errorf("ValidateCreateContactRequest() unexpected errors: %v", errors)
+				}
+			}
+		})
+	}
+}
+
+func TestIsValidEmail(t *testing.T) {
+	tests := []struct {
+		name  string
+		email string
+		want  bool
+	}{
+		{"valid email", "test@example.com", true},
+		{"valid email with subdomain", "test@mail.example.com", true},
+		{"valid email with plus", "test+tag@example.com", true},
+		{"valid email with dot", "test.user@example.com", true},
+		{"empty email", "", false},
+		{"no @ symbol", "not-an-email", false},
+		{"no domain", "test@", false},
+		{"no TLD", "test@example", false},
+		{"invalid format", "@example.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidEmail(tt.email); got != tt.want {
+				t.Errorf("isValidEmail(%q) = %v, want %v", tt.email, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsValidPhone(t *testing.T) {
+	tests := []struct {
+		name  string
+		phone string
+		want  bool
+	}{
+		{"empty phone", "", true}, // Phone is optional
+		{"valid phone with plus", "+1234567890", true},
+		{"valid phone with dashes", "123-456-7890", true},
+		{"valid phone with spaces", "123 456 7890", true},
+		{"valid phone with parentheses", "(123) 456-7890", true},
+		{"valid phone digits only", "1234567890", true},
+		{"too short", "123", false},
+		{"too long", "12345678901234567890", false},
+		{"invalid characters", "abc1234567", false},
+		{"valid international", "+441234567890", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidPhone(tt.phone); got != tt.want {
+				t.Errorf("isValidPhone(%q) = %v, want %v", tt.phone, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add comprehensive validation for email, name, and phone fields
- Email: required, format validation, max 255 characters
- Name: at least one of first_name or last_name required, max 100 chars each
- Phone: optional, format validation when provided
- Return structured 400 Bad Request errors with validation details
- Add unit tests for validation logic (30+ test cases)
- Add integration tests for endpoint behavior

Fixes #11